### PR TITLE
Remove mangos/cMangos logic

### DIFF
--- a/application/models/External_account_model.php
+++ b/application/models/External_account_model.php
@@ -437,9 +437,9 @@ class External_account_model extends CI_Model
         $this->connect();
 
         $this->connection
-            ->table(table("account_access"))
-            ->where(column("account", "id"), $userId)
-            ->update([column("account_access", "SecurityLevel") => $newRank]);
+            ->table('account_access')
+            ->where('id', $userId)
+            ->update(['gmlevel' => $newRank]);
     }
 
     public function setLastIp($userId, $ip)

--- a/application/modules/admin/controllers/Accounts.php
+++ b/application/modules/admin/controllers/Accounts.php
@@ -160,7 +160,7 @@ class Accounts extends MX_Controller
             }
         }
 
-        $external_account_access_data[column("account_access", "gmlevel")] = $this->input->post("gm_level");
+        $external_account_access_data['gmlevel'] = $this->input->post('gm_level');
 
         $internal_account_data["vp"] = $this->input->post("vp");
         $internal_account_data["dp"] = $this->input->post("dp");

--- a/application/modules/admin/models/Accounts_model.php
+++ b/application/modules/admin/models/Accounts_model.php
@@ -98,9 +98,7 @@ class Accounts_model extends CI_Model
     public function getAccessId($userId = 0)
     {
         $query = $this->connection->query(
-            "SELECT " . column("account_access", "gmlevel", true) . " FROM " .
-            table("account_access") . " WHERE " . column("account_access", "id") .
-            " = ?",
+            "SELECT gmlevel FROM account_access WHERE id = ?",
             [$userId]
         );
 
@@ -135,13 +133,13 @@ class Accounts_model extends CI_Model
 
         if ($this->getAccessId($id)) {
             // Update external access
-            $this->connection->table(table('account_access'))
-                ->where(column('account_access', 'id'), $id)
+            $this->connection->table('account_access')
+                ->where('id', $id)
                 ->update($external_account_access_data);
         } else {
             // Insert external access
-            $external_account_access_data[column('account_access', 'id')] = $id;
-            $this->connection->table(table('account_access'))
+            $external_account_access_data['id'] = $id;
+            $this->connection->table('account_access')
                 ->insert($external_account_access_data);
         }
 

--- a/application/modules/pvp_statistics/models/Data_model.php
+++ b/application/modules/pvp_statistics/models/Data_model.php
@@ -14,11 +14,8 @@ class Data_model extends CI_Model
             return false;
         }
 
-        switch ($this->emuStr) {
-            default:
-            {
-                $statements = [
-                    'TopArenaTeams' => "SELECT `arenaTeamId` AS arenateamid, `rating`, `rank`, `arena_team`.`name`, `captainGuid` AS captain, `seasonWins`, `type`, `characters`.`race` AS race FROM `arena_team` RIGHT JOIN `characters` ON `characters`.`guid` = `arena_team`.`captainGuid` WHERE `type` = ? ORDER BY rating DESC LIMIT ?;",
+        $statements = [
+            'TopArenaTeams' => "SELECT `arenaTeamId` AS arenateamid, `rating`, `rank`, `arena_team`.`name`, `captainGuid` AS captain, `seasonWins`, `type`, `characters`.`race` AS race FROM `arena_team` RIGHT JOIN `characters` ON `characters`.`guid` = `arena_team`.`captainGuid` WHERE `type` = ? ORDER BY rating DESC LIMIT ?;",
 
                     'TeamMembers' => "SELECT 
                                     `arena_team_member`.`arenaTeamId` AS arenateamid, 
@@ -33,10 +30,7 @@ class Data_model extends CI_Model
                                 RIGHT JOIN `characters` ON `characters`.`guid` = `arena_team_member`.`guid` 
                                 WHERE `arena_team_member`.`arenateamid` = ? ORDER BY guid ASC;",
                     'TopHKPlayers' => "SELECT `guid`, `name`, `level`, `race`, `class`, `gender`, `totalKills` AS kills FROM `characters` WHERE `totalKills` > 0 ORDER BY `totalKills` DESC LIMIT ?;"
-                ];
-                break;
-            }
-        }
+        ];
 
         return $statements[$key];
     }


### PR DESCRIPTION
## Summary
- simplify admin account controller to always use `account_access.gmlevel`
- drop emulator checks from admin account model
- remove emulator-specific column from External_account_model
- simplify PvP statistics data model

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685547df4c38832e8e46286eb36cfbbc