### PR TITLE
Update emulator list in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,7 +40,7 @@ If applicable, add screenshots to help explain your problem.
  - MySQL version[e.g. 8.0]
  - CMS version[e.g. 9.0.3]
  - Expansion [e.g. Mists of Pandaria, Wotlk, Cataclysm, ...]
- - Selected Emulator [e.g. TrinityCore (3.3.5a), TrinityCore - Legion, TrinityCore - Battle for Azeroth, TrinityCore - Shadowlands, TrinityCore - Dragonflight, TrinityCore - The War Within]
+ - Selected Emulator [e.g. TrinityCore - Legion, TrinityCore - Battle for Azeroth, TrinityCore - Shadowlands, TrinityCore - Dragonflight, TrinityCore - The War Within]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
## Summary
- remove outdated emulator example from bug report template

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b632b2d8832e8b11d058ad565e29