### PR TITLE
Update README emulator support

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -35,7 +35,6 @@ its ease of use and development, safe and secure codebase and dedication to simp
 
 | Emulator                                 | Status |
 |------------------------------------------|:--------:|
-| TrinityCore (3.3.5a)                     | ✅ |
 | TrinityCore - The War Within             | ✅ |
 | TrinityCore - Dragonflight               | ✅ |
 | TrinityCore - Shadowlands                | ✅ |
@@ -46,16 +45,9 @@ its ease of use and development, safe and secure codebase and dedication to simp
 
 | Emulator                             | Status |
 |--------------------------------------|:--------:|
-| Classic                              | ✅ |
-| TBC                                  | ✅ |
-| Wotlk                                | ✅ |
-| Cataclysm                            | ✅ |
-| Mists of Pandaria                    | ✅ |
-| Warlords of Draenor                  | ✅ |
 | Legion                               | ✅ |
 | Battle For Azeroth                   | ✅ |
 | Shadowlands                          | ✅ |
-| Calssic (TBC , Wotlk, Cataclysm)     | ✅ |
 | Dragonflight                         | ✅ |
 | The War Within                       | ✅ |
 


### PR DESCRIPTION
## Summary
- remove outdated TrinityCore 3.3.5a reference
- trim expansions table to Legion and newer

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b62f443c832ea4c5a45a80002daa